### PR TITLE
Apply Plain Kube YAML before app installation

### DIFF
--- a/Dockerfile.invocation-image
+++ b/Dockerfile.invocation-image
@@ -18,5 +18,6 @@ FROM alpine:${ALPINE_VERSION} as invocation
 RUN apk add --no-cache ca-certificates && adduser -S cnab
 USER cnab
 COPY --from=build /go/src/github.com/docker/app/bin/cnab-run /cnab/app/run
+COPY --from=bitnami/kubectl:latest /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/kubectl
 WORKDIR /cnab/app
 CMD /cnab/app/run

--- a/cmd/cnab-run/install.go
+++ b/cmd/cnab-run/install.go
@@ -1,22 +1,32 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/deislabs/cnab-go/bundle"
 	"github.com/docker/app/internal"
 	"github.com/docker/app/internal/packager"
 	"github.com/docker/app/render"
+	"github.com/docker/app/types"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/command/stack"
 	"github.com/docker/cli/cli/command/stack/options"
 	"github.com/docker/cli/cli/command/stack/swarm"
 	composetypes "github.com/docker/cli/cli/compose/types"
+	kubecontext "github.com/docker/cli/cli/context/kubernetes"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -47,6 +57,11 @@ func installAction(instanceName string) error {
 		return err
 	}
 	parameters := packager.ExtractCNABParametersValues(packager.ExtractCNABParameterMapping(app.Parameters()), os.Environ())
+	if orchestrator == command.OrchestratorKubernetes {
+		if err := applyPlainKubernetes(cli, app, parameters); err != nil {
+			return err
+		}
+	}
 	rendered, err := render.Render(app, parameters, imageMap)
 	if err != nil {
 		return err
@@ -65,6 +80,67 @@ func installAction(instanceName string) error {
 		ResolveImage:     swarm.ResolveImageAlways,
 		SendRegistryAuth: sendRegistryAuth,
 	})
+}
+
+func applyPlainKubernetes(cli command.Cli, app *types.App, parameters map[string]string) error {
+	// Parse attachments to find kube-manifest.yml file
+	for _, a := range app.Attachments() {
+		if strings.HasSuffix(a.Path(), "kube-manifest.yml") {
+			buf, err := ioutil.ReadFile(filepath.Join(app.Path, a.Path()))
+			if err != nil {
+				return err
+			}
+			// Read Manifest
+			manifest := []string{}
+			if err := yaml.Unmarshal(buf, &manifest); err != nil {
+				return err
+			}
+			// Retrieve kube context from cli context store
+			kubeConfig, err := kubecontext.ConfigFromContext("cnab", cli.ContextStore())
+			if err != nil {
+				return err
+			}
+			rawCfg, err := kubeConfig.RawConfig()
+			if err != nil {
+				return err
+			}
+			data, err := clientcmd.Write(rawCfg)
+			if err != nil {
+				return err
+			}
+			tmp, err := ioutil.TempDir("", "")
+			if err != nil {
+				return err
+			}
+			configPath := filepath.Join(tmp, "config")
+			if err := ioutil.WriteFile(configPath, data, 0644); err != nil {
+				return err
+			}
+
+			// Apply all the k8s yaml files
+			for _, m := range manifest {
+				fmt.Printf("Applying Kube YAML file %q\n", m)
+				kubeYaml, err := ioutil.ReadFile(filepath.Join(app.Path, m))
+				if err != nil {
+					return err
+				}
+				kubeYamlRendered, err := render.RenderFile(app, parameters, string(kubeYaml))
+				if err != nil {
+					return err
+				}
+
+				kubectlCmd := exec.Command("kubectl", "apply", "-f", "-")
+				kubectlCmd.Stdin = bytes.NewBuffer([]byte(kubeYamlRendered))
+				kubectlCmd.Stdout = os.Stdout
+				kubectlCmd.Stderr = os.Stderr
+				kubectlCmd.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", configPath))
+				if err := kubectlCmd.Run(); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func getFlagset(orchestrator command.Orchestrator) *pflag.FlagSet {

--- a/examples/hello-world/example-hello-world.dockerapp/k8s/deployment.yml
+++ b/examples/hello-world/example-hello-world.dockerapp/k8s/deployment.yml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: ${nginx.port}

--- a/examples/hello-world/example-hello-world.dockerapp/k8s/namespace.yml
+++ b/examples/hello-world/example-hello-world.dockerapp/k8s/namespace.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: ${kube.namespace}
+    labels:
+      name: ${kube.namespace}

--- a/examples/hello-world/example-hello-world.dockerapp/kube-manifest.yml
+++ b/examples/hello-world/example-hello-world.dockerapp/kube-manifest.yml
@@ -1,0 +1,2 @@
+- k8s/namespace.yml
+- k8s/deployment.yml

--- a/examples/hello-world/example-hello-world.dockerapp/parameters.yml
+++ b/examples/hello-world/example-hello-world.dockerapp/parameters.yml
@@ -1,2 +1,6 @@
 port: 8080
 text: Hello, World!
+nginx:
+  port: 8181
+kube:
+  namespace: "mynamespace"


### PR DESCRIPTION
This Proof of Concept just adds kubectl binary into the invocation image, looks for a `kube-manifest.yml` file in the app definition which lists all the kube yaml to apply. Those YAMLs are rendered the same way we do with compose files (so parameters work too!) and then are applied using `kubectl`. In this PoC update and uninstallation are not handled.

Modified the hello world example with dumb kube yaml:
```
# added a kube-manifest file listing all the kube files to apply
$ tree hello-world.dockerapp 
hello-world.dockerapp
├── docker-compose.yml
├── k8s
│   ├── deployment.yml
│   └── namespace.yml
├── kube-manifest.yml
├── metadata.yml
└── parameters.yml
1 directory, 6 files

$ cat hello-world.dockerapp/kube-manifest.yml
- k8s/namespace.yml
- k8s/deployment.yml

$ cat hello-world.dockerapp/k8s/deployment.yml 
apiVersion: apps/v1
kind: Deployment
...
    spec:
      containers:
      - name: nginx
        image: nginx:1.7.9
        ports:
        - containerPort: ${nginx.port}

# Kube YAML files are rendered too
$ cat hello-world.dockerapp/k8s/namespace.yml 
apiVersion: v1
kind: Namespace
metadata:
    name: ${kube.namespace}
    labels:
      name: ${kube.namespace}

$ car hello-world.dockerapp/parameters.yml
port: 8080
text: Hello, World!
nginx:
  port: 8181
kube:
  namespace: "mynamespace"

$ docker app build . -f hello-world.dockerapp -t hello-kube
[+] Building 0.3s (6/6) FINISHED                                                                                                                                                                                                                                                                                                                                           
 => CACHED [internal] load remote build context                                                                                                                                                                                                                                                                                                                       0.0s
 => CACHED copy /context /                                                                                                                                                                                                                                                                                                                                            0.0s
 => [internal] load metadata for docker.io/docker/cnab-app-base:v0.9.0-zeta1-49-gcbf819c597-dirty                                                                                                                                                                                                                                                                     0.0s
 => [1/2] FROM docker.io/docker/cnab-app-base:v0.9.0-zeta1-49-gcbf819c597-dirty                                                                                                                                                                                                                                                                                       0.0s
 => => resolve docker.io/docker/cnab-app-base:v0.9.0-zeta1-49-gcbf819c597-dirty                                                                                                                                                                                                                                                                                       0.0s
 => [2/2] COPY . .                                                                                                                                                                                                                                                                                                                                                    0.1s
 => exporting to image                                                                                                                                                                                                                                                                                                                                                0.0s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                               0.0s
 => => writing image sha256:b0de0c6767e062fb0687d50685e0bdfe19cf426b0a9d2768d76bc0407ac2f11b                                                                                                                                                                                                                                                                          0.0s

# It shows parameters and attachments
$ docker app image inspect hello-kube --pretty
version: 0.1.0
name: hello-world
description: Hello, World!
maintainers:
- name: user
  email: user@email.com

SERVICE REPLICAS PORTS IMAGE
hello   1        8080  docker.io/hashicorp/http-echo:latest@sha256:ba27d460cd1f22a1a4331bdf74f4fccbc025552357e8a3249c40ae216275de96

PARAMETER VALUE
port      8080
text      Hello, World!

ATTACHMENT         SIZE
k8s/deployment.yml 314B
k8s/namespace.yml  145B
kube-manifest.yml  40B

# No deployment yet
$ kubectl get deployments                                                                  
No resources found.

# No extra namespace
$ kubectl get namespaces                                                                      
NAME              STATUS   AGE
default           Active   108d
docker            Active   108d
kube-node-lease   Active   108d
kube-public       Active   108d
kube-system       Active   108d

# Kube YAMLs are applied before running the app
$ docker app run hello-kube --name hello-kube --orchestrator=kubernetes                 
Applying Kube YAML file "k8s/namespace.yml"
namespace/mynamespace created
Applying Kube YAML file "k8s/deployment.yml"
deployment.apps/nginx-deployment created
Waiting for the stack to be stable and running...
hello: Pending
hello: Ready

Stack hello-kube is stable and running

# namespace has been created, using the name defined in parameters
$ kubectl get namespaces                                                         
NAME              STATUS   AGE
default           Active   108d
docker            Active   108d
kube-node-lease   Active   108d
kube-public       Active   108d
kube-system       Active   108d
mynamespace       Active   7s

# nginx deployment is also there, along with the app 
$ kubectl get deployments                                                        
NAME               READY   UP-TO-DATE   AVAILABLE   AGE
hello              1/1     1            1           9s
nginx-deployment   2/2     2            2           10s

# 8181 port should be there, defined in parameters
$ kubectl describe deploy nginx-deployment 
Name:                   nginx-deployment
Namespace:              default
CreationTimestamp:      Thu, 31 Oct 2019 20:05:45 +0100
...
Pod Template:
  Labels:  app=nginx
  Containers:
   nginx:
    Image:        nginx:1.7.9
    Port:         8181/TCP
...
```

**- A picture of a cute animal (not mandatory)**

![image](https://user-images.githubusercontent.com/31478878/68286589-9f342f80-0081-11ea-9e16-76e7755f7be9.png)
